### PR TITLE
Fix error shown on importing items

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -173,7 +173,7 @@ class PickerWindow(Adw.ApplicationWindow):
             self.currentFileTitle = info.get_attribute_string("standard::display-name")
         else:
             self.currentFileTitle = self.loadedFile.get_basename()
-        self.set_title(display_name)
+        self.set_title(f"{self.currentFileTitle} - " + _("Picker"))
 
         self.currentFile = self.loadedFile.peek_path()
         self.currentFileContent = self.loadedFileText.decode("utf-8")


### PR DESCRIPTION
This fixes an exception shown when trying to load exported items in Picker 1.1.0.